### PR TITLE
Fix error when profile is not set

### DIFF
--- a/src/client/modules/core/components/home.js
+++ b/src/client/modules/core/components/home.js
@@ -23,9 +23,11 @@ export default class Home extends Component {
               </CardItem>
 
               <CardItem>
-                  <Text>_id: {user._id}</Text>
-                  <Text>email: {user.emails[0].address}</Text>
-                  <Text>name: {user.profile.firstName + ' ' + user.profile.lastName}</Text>
+                <Text>_id: {user._id}</Text>
+                <Text>email: {user.emails[0].address}</Text>
+                { user.profile && user.profile.firstName && user.profile.lastName ?
+                <Text>name: {user.profile.firstName + ' ' + user.profile.lastName}</Text>
+                : <Text>No profile information</Text> }
               </CardItem>
             </Card>
           }


### PR DESCRIPTION
When user.profile is empty it throws and error when you try to access fields on it.
If I change `< Text >No profile information</ Text >` to `null` it still throws an error.
Any idea why `null` in place of a component is not working in React Native?
